### PR TITLE
Ares tags support and smarter unit size logic and more

### DIFF
--- a/src/Commands/AutoLoad.cpp
+++ b/src/Commands/AutoLoad.cpp
@@ -184,8 +184,8 @@ void AutoLoadCommandClass::Execute(WWKey eInput) const
 		// try to cast to TechnoClass
 		TechnoClass *pTechno = abstract_cast<TechnoClass *>(pUnit);
 
-		// If not a techno, or is in air, then exclude it from auto load feature.
-		if (!pTechno || pTechno->IsInAir())
+		// If not a techno, or is in air, or is MCed, or MCs anything, then it can't be a passenger.
+		if (!pTechno || pTechno->IsInAir() || pTechno->IsMindControlled() || pTechno->CaptureManager->IsControllingSomething())
 		{
 			continue;
 		}
@@ -211,7 +211,7 @@ void AutoLoadCommandClass::Execute(WWKey eInput) const
 		// try to cast to TechnoClass
 		TechnoClass *pTechno = abstract_cast<TechnoClass *>(pUnit);
 
-		// If not a techno, or is in air, then exclude it from auto load feature.
+		// If not a techno, or is in air, then it can't be a vehicle.
 		if (!pTechno || pTechno->IsInAir())
 		{
 			continue;

--- a/src/Commands/AutoLoad.cpp
+++ b/src/Commands/AutoLoad.cpp
@@ -94,7 +94,7 @@ void SpreadPassengersToTransports(std::vector<P> &pPassengers, std::vector<std::
 					// Check passenger filter here.
 					if (pTypeExt)
 					{
-						if (!pTypeExt->CanLoadPassenger(pPassenger))
+						if (!pTypeExt->CanLoadPassenger(pTransport, pPassenger))
 						{
 							continue;
 						}
@@ -154,12 +154,27 @@ void AutoLoadCommandClass::Execute(WWKey eInput) const
 	MapClass::Instance->SetRepairMode(0);
 	MapClass::Instance->SetSellMode(0);
 
-	std::vector<TechnoClass *> infantryIndexArray;
+	// This array is for the standard passengers, most Infantry and small vehicles like terror drones go here.
+	// A techno is added to this array if:
+	// 1. It's an Infantry with size <= 2;
+	// 2. It's a Vehicle with size <= 2, and either has 0 passenger slots, or disallow manual loading.
+	std::vector<TechnoClass *> passengerArray;
+
+	// This array is for larger passengers like tanks. It is not necessarily larger, but has lower loading priority.
+	// A techno is added to this array if:
+	// 1. It's an Infantry with size >= 3;
+	// 2. It's a Vehicle with size >= 3, and either has 0 passenger slots, or disallow manual loading;
+	// 3. It's a Vehicle with passenger slots, allows manual loading, and has size limit <= 2.
+	// 
+	// This array is only loaded into large vehicles if:
+	//   - either "passengerArray" is empty;
+	//   - or nothing in the "passengerArray" can actually be loaded into non-large vehicles.
+	std::vector<TechnoClass *> largePassengerArray;
+
+	// vehicles that can hold size <= 2
 	std::vector<std::pair<TechnoClass *, int>> vehicleIndexArray;
-	// vehicle that can hold size larger than 2 passenger index array
+	// vehicles that can hold size >= 3
 	std::vector<std::pair<TechnoClass *, int>> largeVehicleIndexArray;
-	// full vehicle may be passenger.
-	std::vector<TechnoClass *> mayBePassengerArray;
 	// get current selected units.
 	for (int i = 0; i < ObjectClass::CurrentObjects->Count; i++)
 	{
@@ -167,62 +182,72 @@ void AutoLoadCommandClass::Execute(WWKey eInput) const
 		// try to cast to TechnoClass
 		TechnoClass *pTechno = abstract_cast<TechnoClass *>(pUnit);
 
-		if (pTechno && pTechno->WhatAmI() == AbstractType::Infantry && !pTechno->IsInAir())
+		// If not a techno, or is in air, then exclude it from auto load feature.
+		if (!pTechno || pTechno->IsInAir())
 		{
-			infantryIndexArray.push_back(pTechno);
+			continue;
 		}
-		else if (pTechno && pTechno->WhatAmI() == AbstractType::Unit && !pTechno->IsInAir())
+
+		auto pTechnoType = pTechno->GetTechnoType();
+		auto pTypeExt = TechnoTypeExt::ExtMap.Find(pTechnoType);
+
+		// If it's an Infantry, or it's a Unit with no passenger slots or unable to manually load infantries, add it to the passenger arrays.
+		if ((pTechno->WhatAmI() == AbstractType::Infantry || (pTechno->WhatAmI() == AbstractType::Unit && (pTechnoType->Passengers <= 0 || (pTypeExt && pTypeExt->NoManualEnter)))))
 		{
-			auto pTypeExt = TechnoTypeExt::ExtMap.Find(pTechno->GetTechnoType());
-			bool bySize = true;
-			if (pTypeExt)
-			{
-				// If "NoManualEnter=true" then the transport is excluded from auto load feature. It may still become a passenger.
-				if (pTypeExt->NoManualEnter)
-				{
-					mayBePassengerArray.push_back(pTechno);
-					continue;
-				}
-				bySize = pTypeExt->Passengers_BySize;
-			}
+			if (pTechnoType->Size <= 2)
+				passengerArray.push_back(pTechno);
+			else
+				largePassengerArray.push_back(pTechno);
+		}
+		else if (pTechno->WhatAmI() == AbstractType::Unit)
+		{
+			bool bySize = pTypeExt && pTypeExt->Passengers_BySize;
 
 			// If "Passengers.BySize=false" then only the number of passengers matter.
-			auto const pType = pTechno->GetTechnoType();
-			if (pType->Passengers > 0 && pTechno->Passengers.NumPassengers < pType->Passengers && (!bySize || pTechno->Passengers.GetTotalSize() < pType->Passengers))
+			if (pTechnoType->Passengers > 0
+				&& pTechno->Passengers.NumPassengers < pTechnoType->Passengers
+				&& (!bySize || pTechno->Passengers.GetTotalSize() < pTechnoType->Passengers))
 			{
 				auto const transportTotalSize = bySize ? pTechno->Passengers.GetTotalSize() : pTechno->Passengers.NumPassengers;
-				if (pTechno->GetTechnoType()->SizeLimit > 2)
+				if (pTechnoType->SizeLimit > 2)
 				{
 					largeVehicleIndexArray.push_back(std::make_pair(pTechno, transportTotalSize));
 				}
 				else
 				{
 					vehicleIndexArray.push_back(std::make_pair(pTechno, transportTotalSize));
+					largePassengerArray.push_back(pTechno);
 				}
 			}
 			else
 			{
-				mayBePassengerArray.push_back(pTechno);
+				largePassengerArray.push_back(pTechno);
 			}
 		}
 	}
 
+	// Remove transports from the list with no potential passengers.
+	vehicleIndexArray.erase(
+	std::remove_if(vehicleIndexArray.begin(), vehicleIndexArray.end(),
+		[passengerArray](auto transport)
+		{
+			auto pTypeExt = TechnoTypeExt::ExtMap.Find(transport.first->GetTechnoType());
+			return !pTypeExt->CanLoadAny(transport.first, passengerArray);
+		}),
+	vehicleIndexArray.end());
+
 	// pair the infantry and vehicle
-	if (vehicleIndexArray.size() > 0 && infantryIndexArray.size() > 0)
+	if (vehicleIndexArray.size() > 0 && passengerArray.size() > 0)
 	{
-		SpreadPassengersToTransports(infantryIndexArray, vehicleIndexArray);
+		SpreadPassengersToTransports(passengerArray, vehicleIndexArray);
 	}
 	else if (largeVehicleIndexArray.size() > 0)
 	{
 		// load both infantry and vehicle into large vehicle
-		auto &passengerIndexArray = infantryIndexArray;
-		for (auto vehicle : vehicleIndexArray)
+		auto &passengerIndexArray = passengerArray;
+		for (auto largePassenger : largePassengerArray)
 		{
-			passengerIndexArray.push_back(vehicle.first);
-		}
-		for (auto mayBePassenger : mayBePassengerArray)
-		{
-			passengerIndexArray.push_back(mayBePassenger);
+			passengerIndexArray.push_back(largePassenger);
 		}
 		SpreadPassengersToTransports(passengerIndexArray, largeVehicleIndexArray);
 	}

--- a/src/Commands/AutoLoad.cpp
+++ b/src/Commands/AutoLoad.cpp
@@ -185,7 +185,9 @@ void AutoLoadCommandClass::Execute(WWKey eInput) const
 		TechnoClass *pTechno = abstract_cast<TechnoClass *>(pUnit);
 
 		// If not a techno, or is in air, or is MCed, or MCs anything, then it can't be a passenger.
-		if (!pTechno || pTechno->IsInAir() || pTechno->IsMindControlled() || pTechno->CaptureManager->IsControllingSomething())
+		if (!pTechno || pTechno->IsInAir()
+			|| pTechno->IsMindControlled()
+			|| (pTechno->CaptureManager && pTechno->CaptureManager->IsControllingSomething()))
 		{
 			continue;
 		}

--- a/src/Commands/AutoLoad.cpp
+++ b/src/Commands/AutoLoad.cpp
@@ -241,6 +241,11 @@ void AutoLoadCommandClass::Execute(WWKey eInput) const
 				}
 			}
 
+			// If MCed, or MCs anything, then it can't be a passenger.
+			if (pTechno->IsMindControlled() || pTechno->CaptureManager->IsControllingSomething())
+			{
+				continue;
+			}
 			largePassengerArray.push_back(pTechno);
 		}
 	}

--- a/src/Commands/AutoLoad.cpp
+++ b/src/Commands/AutoLoad.cpp
@@ -234,7 +234,7 @@ void AutoLoadCommandClass::Execute(WWKey eInput) const
 					largeVehicleIndexArray.push_back(std::make_pair(pTechno, transportTotalSize));
 					continue;
 				}
-				else if (pTypeExt->CanLoadAny(pTechno, passengerArray))
+				else if (!pTypeExt || pTypeExt->CanLoadAny(pTechno, passengerArray))
 				{
 					vehicleIndexArray.push_back(std::make_pair(pTechno, transportTotalSize));
 					continue;

--- a/src/Ext/TechnoType/Body.cpp
+++ b/src/Ext/TechnoType/Body.cpp
@@ -27,6 +27,9 @@ void TechnoTypeExt::ExtData::ApplyTurretOffset(Matrix3D* mtx, double factor)
 	mtx->Translate(x, y, z);
 }
 
+// Checks if a transport can load a passenger.
+// Note that this function only checks the size limit and Ares passenger whitelist and blacklist,
+// it doesn't check if this transport is actually a transport or not.
 bool TechnoTypeExt::ExtData::CanLoadPassenger(TechnoClass* pTransport, TechnoClass* pPassenger) const
 {
 	auto const pTransportType = pTransport->GetTechnoType();

--- a/src/Ext/TechnoType/Body.cpp
+++ b/src/Ext/TechnoType/Body.cpp
@@ -32,6 +32,8 @@ bool TechnoTypeExt::ExtData::CanLoadPassenger(TechnoClass* pTransport, TechnoCla
 	auto const pTransportType = pTransport->GetTechnoType();
 	auto const pPassengerType = pPassenger->GetTechnoType();
 	return pTransportType->Passengers > 0
+		&& !this->NoManualEnter
+		&& (pTransport->Passengers.NumPassengers < pTransportType->Passengers)
 		&& (pTransportType->SizeLimit <= 0 || pTransportType->SizeLimit >= pPassengerType->Size)
 		&& (!this->Passengers_BySize || (pTransport->Passengers.GetTotalSize() + pPassengerType->Size) <= pTransportType->Passengers)
 		&& (this->PassengersWhitelist.empty() || this->PassengersWhitelist.Contains(pPassengerType))
@@ -40,6 +42,13 @@ bool TechnoTypeExt::ExtData::CanLoadPassenger(TechnoClass* pTransport, TechnoCla
 
 bool TechnoTypeExt::ExtData::CanLoadAny(TechnoClass* pTransport, std::vector<TechnoClass*> pPassengerList) const
 {
+	auto const pTransportType = pTransport->GetTechnoType();
+	if (pTransportType->Passengers <= 0
+		|| this->NoManualEnter
+		|| pTransport->Passengers.NumPassengers >= pTransportType->Passengers)
+	{
+		return false;
+	}
 	for (auto pPassenger : pPassengerList)
 	{
 		if (this->CanLoadPassenger(pTransport, pPassenger))

--- a/src/Ext/TechnoType/Body.cpp
+++ b/src/Ext/TechnoType/Body.cpp
@@ -31,10 +31,7 @@ bool TechnoTypeExt::ExtData::CanLoadPassenger(TechnoClass* pTransport, TechnoCla
 {
 	auto const pTransportType = pTransport->GetTechnoType();
 	auto const pPassengerType = pPassenger->GetTechnoType();
-	return pTransportType->Passengers > 0
-		&& !this->NoManualEnter
-		&& (pTransport->Passengers.NumPassengers < pTransportType->Passengers)
-		&& (pTransportType->SizeLimit <= 0 || pTransportType->SizeLimit >= pPassengerType->Size)
+	return (pTransportType->SizeLimit <= 0 || pTransportType->SizeLimit >= pPassengerType->Size)
 		&& (!this->Passengers_BySize || (pTransport->Passengers.GetTotalSize() + pPassengerType->Size) <= pTransportType->Passengers)
 		&& (this->PassengersWhitelist.empty() || this->PassengersWhitelist.Contains(pPassengerType))
 		&& !this->PassengersBlacklist.Contains(pPassengerType);
@@ -42,13 +39,6 @@ bool TechnoTypeExt::ExtData::CanLoadPassenger(TechnoClass* pTransport, TechnoCla
 
 bool TechnoTypeExt::ExtData::CanLoadAny(TechnoClass* pTransport, std::vector<TechnoClass*> pPassengerList) const
 {
-	auto const pTransportType = pTransport->GetTechnoType();
-	if (pTransportType->Passengers <= 0
-		|| this->NoManualEnter
-		|| pTransport->Passengers.NumPassengers >= pTransportType->Passengers)
-	{
-		return false;
-	}
 	for (auto pPassenger : pPassengerList)
 	{
 		if (this->CanLoadPassenger(pTransport, pPassenger))

--- a/src/Ext/TechnoType/Body.cpp
+++ b/src/Ext/TechnoType/Body.cpp
@@ -27,11 +27,21 @@ void TechnoTypeExt::ExtData::ApplyTurretOffset(Matrix3D* mtx, double factor)
 	mtx->Translate(x, y, z);
 }
 
+bool TechnoTypeExt::ExtData::CanLoadPassenger(TechnoClass* pPassenger) const
+{
+	auto const pPassengerType = pPassenger->GetTechnoType();
+	return (this->PassengersWhitelist.empty() ||
+			this->PassengersWhitelist.Contains(pPassengerType))
+		&& !this->PassengersBlacklist.Contains(pPassengerType);
+}
+
 void TechnoTypeExt::ApplyTurretOffset(TechnoTypeClass* pType, Matrix3D* mtx, double factor)
 {
 	if (auto ext = TechnoTypeExt::ExtMap.Find(pType))
 		ext->ApplyTurretOffset(mtx, factor);
 }
+
+
 
 // Ares 0.A source
 const char* TechnoTypeExt::ExtData::GetSelectionGroupID() const
@@ -245,6 +255,11 @@ void TechnoTypeExt::ExtData::LoadFromINIFile(CCINIClass* const pINI)
 	this->SelfHealGainType.Read(exINI, pSection, "SelfHealGainType");
 	this->Passengers_SyncOwner.Read(exINI, pSection, "Passengers.SyncOwner");
 	this->Passengers_SyncOwner_RevertOnExit.Read(exINI, pSection, "Passengers.SyncOwner.RevertOnExit");
+
+	this->PassengersWhitelist.Read(exINI, pSection, "Passengers.Allowed");
+	this->PassengersBlacklist.Read(exINI, pSection, "Passengers.Disallowed");
+	this->Passengers_BySize.Read(exINI, pSection, "Passengers.BySize");
+	this->NoManualEnter.Read(exINI, pSection, "NoManualEnter");
 
 	this->IronCurtain_KeptOnDeploy.Read(exINI, pSection, "IronCurtain.KeptOnDeploy");
 	this->IronCurtain_Effect.Read(exINI, pSection, "IronCurtain.Effect");
@@ -601,6 +616,11 @@ void TechnoTypeExt::ExtData::Serialize(T& Stm)
 		.Process(this->SelfHealGainType)
 		.Process(this->Passengers_SyncOwner)
 		.Process(this->Passengers_SyncOwner_RevertOnExit)
+
+		.Process(this->PassengersWhitelist)
+		.Process(this->PassengersBlacklist)
+		.Process(this->Passengers_BySize)
+		.Process(this->NoManualEnter)
 
 		.Process(this->PronePrimaryFireFLH)
 		.Process(this->ProneSecondaryFireFLH)

--- a/src/Ext/TechnoType/Body.cpp
+++ b/src/Ext/TechnoType/Body.cpp
@@ -27,12 +27,27 @@ void TechnoTypeExt::ExtData::ApplyTurretOffset(Matrix3D* mtx, double factor)
 	mtx->Translate(x, y, z);
 }
 
-bool TechnoTypeExt::ExtData::CanLoadPassenger(TechnoClass* pPassenger) const
+bool TechnoTypeExt::ExtData::CanLoadPassenger(TechnoClass* pTransport, TechnoClass* pPassenger) const
 {
+	auto const pTransportType = pTransport->GetTechnoType();
 	auto const pPassengerType = pPassenger->GetTechnoType();
-	return (this->PassengersWhitelist.empty() ||
-			this->PassengersWhitelist.Contains(pPassengerType))
+	return pTransportType->Passengers > 0
+		&& (pTransportType->SizeLimit <= 0 || pTransportType->SizeLimit >= pPassengerType->Size)
+		&& (!this->Passengers_BySize || (pTransport->Passengers.GetTotalSize() + pPassengerType->Size) <= pTransportType->Passengers)
+		&& (this->PassengersWhitelist.empty() || this->PassengersWhitelist.Contains(pPassengerType))
 		&& !this->PassengersBlacklist.Contains(pPassengerType);
+}
+
+bool TechnoTypeExt::ExtData::CanLoadAny(TechnoClass* pTransport, std::vector<TechnoClass*> pPassengerList) const
+{
+	for (auto pPassenger : pPassengerList)
+	{
+		if (this->CanLoadPassenger(pTransport, pPassenger))
+		{
+			return true;
+		}
+	}
+	return false;
 }
 
 void TechnoTypeExt::ApplyTurretOffset(TechnoTypeClass* pType, Matrix3D* mtx, double factor)

--- a/src/Ext/TechnoType/Body.h
+++ b/src/Ext/TechnoType/Body.h
@@ -484,7 +484,8 @@ public:
 
 		void ApplyTurretOffset(Matrix3D* mtx, double factor = 1.0);
 
-		bool CanLoadPassenger(TechnoClass* pPassenger) const;
+		bool CanLoadPassenger(TechnoClass* pTransport, TechnoClass* pPassenger) const;
+		bool CanLoadAny(TechnoClass* pTransport, std::vector<TechnoClass*> pPassengerList) const;
 
 		// Ares 0.A
 		const char* GetSelectionGroupID() const;

--- a/src/Ext/TechnoType/Body.h
+++ b/src/Ext/TechnoType/Body.h
@@ -157,6 +157,11 @@ public:
 		Valueable<bool> Passengers_SyncOwner;
 		Valueable<bool> Passengers_SyncOwner_RevertOnExit;
 
+		ValueableVector<TechnoTypeClass*> PassengersWhitelist;
+		ValueableVector<TechnoTypeClass*> PassengersBlacklist;
+		Valueable<bool> Passengers_BySize;
+		Valueable<bool> NoManualEnter;
+
 		Nullable<bool> IronCurtain_KeptOnDeploy;
 		Nullable<IronCurtainEffect> IronCurtain_Effect;
 		Nullable<WarheadTypeClass*> IronCurtain_KillWarhead;
@@ -379,6 +384,11 @@ public:
 			, Passengers_SyncOwner { false }
 			, Passengers_SyncOwner_RevertOnExit { true }
 
+			, PassengersWhitelist {}
+			, PassengersBlacklist {}
+			, Passengers_BySize { true }
+			, NoManualEnter { false }
+
 			, PronePrimaryFireFLH {}
 			, ProneSecondaryFireFLH {}
 			, DeployedPrimaryFireFLH {}
@@ -473,6 +483,8 @@ public:
 		virtual void SaveToStream(PhobosStreamWriter& Stm) override;
 
 		void ApplyTurretOffset(Matrix3D* mtx, double factor = 1.0);
+
+		bool CanLoadPassenger(TechnoClass* pPassenger) const;
 
 		// Ares 0.A
 		const char* GetSelectionGroupID() const;


### PR DESCRIPTION
Effects:
1. Transports with `NoManualEnter=true` will be viewed as if they didn't have passenger slots;
2. If a transport has `Passengers.BySize=false` then every potential passenger is viewed as size 1;
3. If a transport has `Passengers.Allowed=` and `Passengers.Disallowed=` defined then passengers unable to enter it will not try to get into it, as well as the auto assignment will never try to violent the `SizeLimit=`;
4. Vehicle types with size <= 2 and passenger <= 0 are viewed as standard passengers like infantry types, and infantry types with size >= 3 are viewed as larger passengers like tanks;
5. If a standard transport can't actually load anything due to its passenger filters, then just try to load it into larger transports;
6. Mind controlled units and units mind controlling something can't be passengers at all.

Maybe we have to detect if Ares is present before we take compatibility with Ares tags?